### PR TITLE
Ar 78 bug avec les GitHub actions du deploiement sur serveur

### DIFF
--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -28,6 +28,8 @@ jobs:
             git switch main
             git pull origin main
             cp -r ./* /home/beafowl/A-Rien
+            cp /root/.env /home/beafowl/A-Rien/back
+            cp /root/.env.development /home/beafowl/A-Rien/front
             sh /home/beafowl/re.sh &
 
       - name: executing remote ssh commands using ssh key
@@ -45,4 +47,6 @@ jobs:
             git switch dev
             git pull origin dev
             cp -r ./* /home/beafowl/A-Rien
+            cp /root/.env /home/beafowl/A-Rien/back
+            cp /root/.env.development /home/beafowl/A-Rien/front
             sh /home/beafowl/re.sh &

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/main' && github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}
@@ -33,7 +33,7 @@ jobs:
             sh /home/beafowl/re.sh &
 
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/dev' && github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - dev
+      - AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur
 
 name: 🚀 Deploy Server on push
 jobs:
@@ -13,40 +14,24 @@ jobs:
       - name: 🚚 Get latest code
         uses: actions/checkout@v3
 
-      - name: 📂 Sync files
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/AR-37-init-back'
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          port: 21
-          local-dir: ./
-          server-dir: /home/beafowl/
-
-      - name: 📂 Sync files
-        if: github.ref == 'refs/heads/dev'
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
-        with:
-          server: ${{ secrets.FTP_SERVER }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          port: 2222
-          local-dir: ./
-          server-dir: /home/beafowl/
-
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/AR-37-init-back'
+        if: github.ref == 'refs/heads/main' && github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}
           username: root
           password: ${{ secrets.FTP_PASSWORD }}
           key: ${{ secrets.SSH_KEY }}
-          script: sh re.sh &
+          script: |
+            git clone https://github.com/BRAVMM/A-Rien.git
+            cd A-Rien
+            git switch main
+            git pull origin main
+            cp -r ./* /home/beafowl/A-Rien
+            sh /home/beafowl/re.sh &
 
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/dev' && github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}
@@ -54,4 +39,10 @@ jobs:
           password: ${{ secrets.FTP_PASSWORD }}
           key: ${{ secrets.SSH_KEY }}
           port: 2121
-          script: sh re.sh &
+          script: |
+            git clone https://github.com/BRAVMM/A-Rien.git
+            cd A-Rien
+            git switch dev
+            git pull origin dev
+            cp -r ./* /home/beafowl/A-Rien
+            sh /home/beafowl/re.sh &

--- a/.github/workflows/deploy-on-server.yml
+++ b/.github/workflows/deploy-on-server.yml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - dev
-      - AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur
 
 name: 🚀 Deploy Server on push
 jobs:
@@ -15,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
+        if: github.ref == 'refs/heads/main'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}
@@ -33,7 +32,7 @@ jobs:
             sh /home/beafowl/re.sh &
 
       - name: executing remote ssh commands using ssh key
-        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/AR-78-bug-avec-les-github-actions-du-deploiement-sur-serveur'
+        if: github.ref == 'refs/heads/dev'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.FTP_SERVER }}


### PR DESCRIPTION
<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Checklist before requesting a review**
- [x] The commits messages follows our guidelines
- [x] I have performed a self-review of my code
- [ ] I have documented my code
- [ ] Do we need to implement unit tests?

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of changes does this PR introduce?** (You can choose multiple)
- [x] Bug fix
- [ ] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved deployment process by adding a new branch to trigger the deployment workflow.
	- Deployment scripts now differentiate between production and development environments for more targeted updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->